### PR TITLE
Fixes w3 XPATH expression

### DIFF
--- a/svgConverter.py
+++ b/svgConverter.py
@@ -36,7 +36,7 @@ def convert_file(filename):
     f.write('var paper = Raphael(\"paper\", width, height);\n\
 var text = "Width = \"+width+\"\\n Height = \"+height;\n\
 \nvar paths = [')
-    totalpaths = doc.findall("./{http://www.w3.org/2000/svg}path")
+    totalpaths = doc.findall(".//{http://www.w3.org/2000/svg}path")
     lastpath = totalpaths.pop()
     for result in totalpaths:
       newid = result.get('id').replace('-', '').replace('.','e').replace(' ','n').upper()


### PR DESCRIPTION
The XPath expression on the ElementTree.findall was missing a `/`, and thus searching for a matching tag, returning an empty list. It failed on line 40, trying to pop an empty list

Source for the fix: http://stackoverflow.com/a/9112373

Source svg: http://upload.wikimedia.org/wikipedia/commons/c/c0/Brazil_states.svg
